### PR TITLE
Backport 596b075591c4b2fe01bee7142f4d0a5f892647ed

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -43,11 +43,9 @@ AC_DEFUN_ONCE([LIB_DETERMINE_DEPENDENCIES],
   if test "x$OPENJDK_TARGET_OS" = xwindows || test "x$OPENJDK_TARGET_OS" = xmacosx; then
     # No X11 support on windows or macosx
     NEEDS_LIB_X11=false
-  elif test "x$ENABLE_HEADLESS_ONLY" = xtrue; then
-    # No X11 support needed when building headless only
-    NEEDS_LIB_X11=false
   else
-    # All other instances need X11
+    # All other instances need X11, even if building headless only, libawt still
+    # needs X11 headers.
     NEEDS_LIB_X11=true
   fi
 


### PR DESCRIPTION
I'd like to backport JDK-8258465 to jdk17u. The changes make configure to look up for X11 header that are REQUIRED even for HEADLESS builds. 

The original patch applied cleanly

Tested with

- temporary rename your X11 include directory (usually /usr/include/X11)
- configure headless-only build with --enable-headless-only flag

EXPECTED result: configuration FAILS with

`configure: error: Could not find X11 libraries. You might be able to fix this by running 'sudo apt-get install libx11-dev libxext-dev libxrender-dev libxrandr-dev libxtst-dev libxt-dev'.
`